### PR TITLE
mimic-tomcat 支持xml和SPI读取配置的servlet和filter信息

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+.idea

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ASMIdeaPluginConfiguration">
     <asm skipDebug="false" skipFrames="false" skipCode="false" expandFrames="false" />

--- a/mimic-tomcat/pom.xml
+++ b/mimic-tomcat/pom.xml
@@ -34,5 +34,15 @@
             <artifactId>cglib</artifactId>
             <version>3.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jaxen</groupId>
+            <artifactId>jaxen</artifactId>
+            <version>2.0.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/mimic-tomcat/src/main/java/com/attackonarchitect/MimicTomcatServer.java
+++ b/mimic-tomcat/src/main/java/com/attackonarchitect/MimicTomcatServer.java
@@ -18,6 +18,7 @@ import com.attackonarchitect.handler.MimicHttpInBoundHandler;
 import com.attackonarchitect.listener.Notifier;
 import com.attackonarchitect.listener.NotifierImpl;
 
+import java.io.File;
 import java.util.Objects;
 
 /**
@@ -49,6 +50,12 @@ public class MimicTomcatServer {
         } else {
             throw new UnsupportedOperationException("不支持的文件格式:  " + configFile);
         }
+        this.doStart();
+    }
+
+    public void start(ClassLoader classLoader) {
+        scanner = new SpiComponentScanner(classLoader);
+
         this.doStart();
     }
 

--- a/mimic-tomcat/src/main/java/com/attackonarchitect/MimicTomcatServer.java
+++ b/mimic-tomcat/src/main/java/com/attackonarchitect/MimicTomcatServer.java
@@ -18,6 +18,8 @@ import com.attackonarchitect.handler.MimicHttpInBoundHandler;
 import com.attackonarchitect.listener.Notifier;
 import com.attackonarchitect.listener.NotifierImpl;
 
+import java.util.Objects;
+
 /**
  * @description:
  */
@@ -32,9 +34,26 @@ public class MimicTomcatServer {
     private ComponentScanner scanner;
     private ServletContext servletContext;
     public void start(Class<?> clazz){
-
         scanner = new WebComponentScanner(clazz);
-        Notifier notifier = new NotifierImpl(scanner.getWebListenerComponents());
+        this.doStart();
+    }
+
+    /**
+     * 依据配置文件初始化
+     *
+     * @param configFile 配置文件路径
+     */
+    public void start(String configFile) {
+        if (configFile.endsWith(".xml")) {
+            scanner = new XmlComponentScanner(configFile);
+        } else {
+            throw new UnsupportedOperationException("不支持的文件格式:  " + configFile);
+        }
+        this.doStart();
+    }
+
+    private void doStart() {
+        Notifier notifier = new NotifierImpl(Objects.requireNonNull(scanner, "没有找到合适的组件扫描器").getWebListenerComponents());
         servletContext = ServletContextFactory.getInstance(scanner.getWebListenerComponents(),notifier);
         servletContext.setAttribute("notifier",notifier);
 

--- a/mimic-tomcat/src/main/java/com/attackonarchitect/SpiComponentScanner.java
+++ b/mimic-tomcat/src/main/java/com/attackonarchitect/SpiComponentScanner.java
@@ -1,0 +1,121 @@
+package com.attackonarchitect;
+
+import com.attackonarchitect.filter.WebFilter;
+import com.attackonarchitect.filter.chain.Filter;
+import com.attackonarchitect.listener.EventListener;
+import com.attackonarchitect.listener.request.ServletRequestAttributeListener;
+import com.attackonarchitect.listener.webcontext.ServletContextListener;
+import com.attackonarchitect.servlet.Servlet;
+import com.attackonarchitect.servlet.ServletInformation;
+import com.attackonarchitect.servlet.ServletInformationBuilder;
+import com.attackonarchitect.servlet.WebServlet;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * spi组件扫描
+ *
+ * @author <a href="mailto:675464934@qq.com">Terrdi</a>
+ * @date 2023/11/14
+ * @since 1.8
+ **/
+public class SpiComponentScanner implements ComponentScanner {
+    private final List<EventListener> webListenerComponents = new ArrayList<>();
+
+    private final Map<String, String> webServletComponents = new HashMap<>();
+
+    private final Map<String, ServletInformation> servletInformationMap = new HashMap<>();
+
+    private final Map<String, Set<String>> webFilterComponents = new HashMap<>();
+
+    private final ClassLoader classLoader;
+
+    public SpiComponentScanner(ClassLoader classLoader) {
+        this.classLoader = Optional.ofNullable(classLoader).orElseGet(Thread.currentThread()::getContextClassLoader);
+        this.init();
+    }
+
+    private void init() {
+        this.initListeners();
+
+        this.initServlet();
+
+        this.initFilters();
+    }
+
+    private void initListeners() {
+        ServiceLoader<ServletContextListener> listenerLoader = ServiceLoader.load(ServletContextListener.class, this.classLoader);
+
+        for (ServletContextListener listener : listenerLoader) {
+            // 解析出监听器相关信息
+            this.webListenerComponents.add(listener);
+        }
+    }
+
+    private void initServlet() {
+        ServiceLoader<Servlet> servletLoader = ServiceLoader.load(Servlet.class, this.classLoader);
+
+        for (Servlet servlet : servletLoader) {
+            // 解析出监听器相关信息
+            String servletClassName = servlet.getClass().getName();
+            WebServlet webServlet = servlet.getClass().getAnnotation(WebServlet.class);
+            if (Objects.isNull(webServlet)) {
+                System.err.println(servletClassName + " 需要被 @WebServlet 注解");
+                continue;
+            }
+
+            ServletInformation servletInformation = new ServletInformationBuilder()
+                    .setClassName(servletClassName)
+                    .setUrlPattern(webServlet.value())
+                    .setLoadOnStartup(webServlet.loadOnStartup())
+                    .setInitParams(webServlet.initParams())
+                    .build();
+
+            for (String uri : webServlet.value()) {
+                this.webServletComponents.put(uri, servletClassName);
+                this.servletInformationMap.put(uri, servletInformation);
+            }
+        }
+    }
+
+    private void initFilters() {
+        ServiceLoader<Filter> filterLoader = ServiceLoader.load(Filter.class, this.classLoader);
+
+        for (Filter filter : filterLoader) {
+            String filterClassName = filter.getClass().getName();
+            WebFilter webFilter = filter.getClass().getAnnotation(WebFilter.class);
+            if (Objects.isNull(webFilter)) {
+                System.err.println(filterClassName + " 需要被 @WebFilter 注解");
+                continue;
+            }
+
+            for (String uri : webFilter.value()) {
+                this.webFilterComponents.computeIfAbsent(uri, key -> new HashSet<>());
+                this.webFilterComponents.get(uri).add(filterClassName);
+            }
+        }
+    }
+
+
+    @Override
+    public List<String> getWebListenerComponents() {
+        return this.webListenerComponents.stream().map(EventListener::getClass).map(Class::getName)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Map<String, String> getWebServletComponents() {
+        return this.webServletComponents;
+    }
+
+    @Override
+    public Map<String, ServletInformation> getServletInformationMap() {
+        return this.servletInformationMap;
+    }
+
+    @Override
+    public Map<String, Set<String>> getWebFilterComponents() {
+        return this.webFilterComponents;
+    }
+}

--- a/mimic-tomcat/src/main/java/com/attackonarchitect/XmlComponentScanner.java
+++ b/mimic-tomcat/src/main/java/com/attackonarchitect/XmlComponentScanner.java
@@ -1,0 +1,182 @@
+package com.attackonarchitect;
+
+import com.attackonarchitect.servlet.ServletInformation;
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.Element;
+import org.dom4j.Node;
+import org.dom4j.io.SAXReader;
+
+import java.net.URL;
+import java.util.*;
+
+/**
+ * 依据xml扫描当前Tomcat组件
+ *
+ * @author <a href="mailto:675464934@qq.com">Terrdi</a>
+ * @date 2023/11/13
+ * @since 1.8
+ **/
+public class XmlComponentScanner implements ComponentScanner {
+    private final List<String> webListenerComponents = new ArrayList<>();
+
+    private final Map<String, String> webServletComponents = new HashMap<>();
+
+    private final Map<String, ServletInformation> servletInformationMap = new HashMap<>();
+
+    private final Map<String, Set<String>> webFilterComponents = new HashMap<>();
+
+    private final String resource;
+
+    public XmlComponentScanner(String resource) {
+        this.resource = resource;
+
+        this.init();
+    }
+
+    /**
+     * 扫描xml结点信息完成初始化
+     */
+    private void init() {
+        // 尝试读取出配置文件信息
+        SAXReader reader = new SAXReader();
+        Document document = null;
+
+        try {
+            URL url = this.getClass().getResource(this.resource);
+            document = reader.read(url);
+        } catch (DocumentException e) {
+            throw new RuntimeException(e);
+        }
+
+        // 扫描结点
+        Iterator<Element> iterator = document.getRootElement().elementIterator();
+        while (iterator.hasNext()) {
+            Element currElement = iterator.next();
+
+            String nodeName = currElement.getName();
+            switch (nodeName) {
+                case "display-name":
+                    System.out.println("当前显示名称为: " + currElement.getText());
+                    break;
+                case "description":
+                    System.out.println("当前应用描述为： " + currElement.getText());
+                    break;
+                case "welcome-file-list":
+                    this.welcomeFileList(currElement);
+                    break;
+                case "listener":
+                    this.listener(currElement);
+                    break;
+                case "servlet":
+                    this.servlet(currElement);
+                    break;
+                case "servlet-mapping":
+                    this.servletMapping(currElement);
+                    break;
+            }
+        }
+    }
+
+    private void servlet(final Element element) {
+        ServletInformation servletInformation = new ServletInformation();
+
+        // 获取到该servlet的相关信息
+        final String servletName = element.elementText("servlet-name");
+        final String servletClass = element.elementText("servlet-class");
+        if (servletName == null || servletName.isEmpty()) {
+            throw new IllegalArgumentException("xml 无法解析 servlet-name:\n" + element.asXML());
+        }
+        if (servletClass == null || servletClass.isEmpty()) {
+            throw new IllegalArgumentException("xml 无法解析 servlet-class:\n" + element.asXML());
+        }
+
+        servletInformation.setClazzName(servletClass);
+        servletInformation.setLoadOnStartup(Integer.parseInt(
+                element.elementText("load-on-startup")));
+        servletInformation.setInitParams(this.resolveInitParam(element));
+
+
+        if (this.webServletComponents.containsKey(servletName)) {
+            // 优先解析到了 servlet-mapping, 补充servlet信息
+            String urlPattern = this.webServletComponents.remove(servletName);
+            servletInformation.setUrlPattern(urlPattern.split(";"));
+            this.webServletComponents.put(urlPattern, servletClass);
+        } else {
+            this.servletInformationMap.put(servletName, servletInformation);
+        }
+    }
+
+    private void servletMapping(final Element element) {
+        final String servletName = element.elementText("servlet-name");
+        String urlPattern = element.elementText("url-pattern");
+        if (servletName == null || servletName.isEmpty()) {
+            throw new IllegalArgumentException("xml 无法解析 servlet-name:\n" + element.asXML());
+        }
+
+        if (this.servletInformationMap.containsKey(servletName)) {
+            // 已经解析了 servlet
+            ServletInformation servletInformation = this.servletInformationMap.remove(servletName);
+            servletInformation.setUrlPattern(urlPattern.split(";"));
+            this.servletInformationMap.put(urlPattern, servletInformation);
+            this.webServletComponents.put(urlPattern, servletInformation.getClazzName());
+        } else {
+            // 还没有解析 servlet
+            this.webServletComponents.put(servletName, urlPattern);
+        }
+    }
+
+    /**
+     * 解析出初始化参数结点
+     * @param element servlet结点
+     * @return 返回该servlet结点下所有初始化参数
+     */
+    private Map<String, String> resolveInitParam(final Element element) {
+        List<Element> list = element.elements("init-param");
+
+        Map<String, String> ret = new HashMap<>();
+        for (Element element0 : list) {
+            String paramName = element0.elementText("param-name");
+            String paramValue = element0.elementText("param-value");
+            ret.put(paramName, paramValue);
+        }
+        return ret;
+    }
+
+    private void welcomeFileList(final Element element) {
+        System.out.println("开始欢迎页面的列表如下: ");
+        List<Element> list = element.elements("welcome-file");
+
+        list.stream().map(Node::getText).forEachOrdered(System.out::println);
+    }
+
+    private void listener(final Element element) {
+        List<Element> list = element.elements("listener-class");
+
+        if (list.isEmpty()) {
+            System.err.println("找不到监听器实现类");
+        } else {
+            this.webListenerComponents.add(list.get(0).getText().trim());
+        }
+    }
+
+    @Override
+    public List<String> getWebListenerComponents() {
+        return this.webListenerComponents;
+    }
+
+    @Override
+    public Map<String, String> getWebServletComponents() {
+        return this.webServletComponents;
+    }
+
+    @Override
+    public Map<String, ServletInformation> getServletInformationMap() {
+        return this.servletInformationMap;
+    }
+
+    @Override
+    public Map<String, Set<String>> getWebFilterComponents() {
+        return this.webFilterComponents;
+    }
+}

--- a/mimic-tomcat/src/main/java/com/attackonarchitect/servlet/ServletManagerImpl.java
+++ b/mimic-tomcat/src/main/java/com/attackonarchitect/servlet/ServletManagerImpl.java
@@ -6,10 +6,7 @@ import com.attackonarchitect.context.ServletContext;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @description:
@@ -43,11 +40,10 @@ public class ServletManagerImpl implements ServletManager {
         //新增 loadOnStartup 初始化功能
         Collection<ServletInformation> values = provider.getServletInformationMap().values();
 
-        values.forEach(information -> {
-            if (information.getLoadOnStartup() > 0) {
-                instantiate(information);
-            }
-        });
+        // 依据loadOnStartup顺序进行初始化
+        values.stream().filter(info -> info.getLoadOnStartup() > 0)
+                .sorted(Comparator.comparingInt(ServletInformation::getLoadOnStartup))
+                .forEachOrdered(this::instantiate);
 
 
     }
@@ -78,7 +74,7 @@ public class ServletManagerImpl implements ServletManager {
         ServletInformation servletInformation = servletInformationMap.get(uri);
 //        Map<String, String> webServletComponents = provider.getWebServletComponents();
 //        String clazzName = webServletComponents.get(uri);
-        Servlet ret = null;
+        Servlet ret;
         ret = instantiate(servletInformation);
         return ret;
     }

--- a/mimic-tomcat/src/main/java/com/attackonarchitect/servlet/ServletManagerImpl.java
+++ b/mimic-tomcat/src/main/java/com/attackonarchitect/servlet/ServletManagerImpl.java
@@ -113,19 +113,21 @@ public class ServletManagerImpl implements ServletManager {
 
                 Class<?> finalClazz = clazz;
                 Servlet finalInstance = instance;
-                initParams.forEach((key, value) -> {
-                    try {
-                        String setterName = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
-                        Method method = finalClazz.getMethod(setterName,value.getClass());
-                        method.invoke(finalInstance,value);
-                    } catch (NoSuchMethodException e) {
-                        throw new RuntimeException(e);
-                    } catch (InvocationTargetException e) {
-                        throw new RuntimeException(e);
-                    } catch (IllegalAccessException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+                if (Objects.nonNull(initParams)) {
+                    initParams.forEach((key, value) -> {
+                        try {
+                            String setterName = "set" + key.substring(0, 1).toUpperCase() + key.substring(1);
+                            Method method = finalClazz.getMethod(setterName,value.getClass());
+                            method.invoke(finalInstance,value);
+                        } catch (NoSuchMethodException e) {
+                            throw new RuntimeException(e);
+                        } catch (InvocationTargetException e) {
+                            throw new RuntimeException(e);
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                }
 
 
                 String[] urlPatterns = servletInformation.getUrlPattern();

--- a/mimic-tomcat/src/test/java/project/StartUp.java
+++ b/mimic-tomcat/src/test/java/project/StartUp.java
@@ -2,6 +2,7 @@ package project;
 
 import com.attackonarchitect.MimicTomcatServer;
 import com.attackonarchitect.WebScanPackage;
+import com.sun.tools.javac.util.ServiceLoader;
 
 /**
  * @description:
@@ -10,7 +11,13 @@ import com.attackonarchitect.WebScanPackage;
 @WebScanPackage
 public class StartUp {
     public static void main(String[] args) {
+        // 注解启动
 //        new MimicTomcatServer(9999).start(StartUp.class);
+
+        // xml启动
         new MimicTomcatServer(9999).start("/WEB-INF/web.xml");
+
+        // SPI 启动
+//        new MimicTomcatServer(9999).start(StartUp.class.getClassLoader());
     }
 }

--- a/mimic-tomcat/src/test/java/project/StartUp.java
+++ b/mimic-tomcat/src/test/java/project/StartUp.java
@@ -10,6 +10,7 @@ import com.attackonarchitect.WebScanPackage;
 @WebScanPackage
 public class StartUp {
     public static void main(String[] args) {
-        new MimicTomcatServer(9999).start(StartUp.class);
+//        new MimicTomcatServer(9999).start(StartUp.class);
+        new MimicTomcatServer(9999).start("/WEB-INF/web.xml");
     }
 }

--- a/mimic-tomcat/src/test/resources/META-INF/services/com.attackonarchitect.filter.chain.Filter
+++ b/mimic-tomcat/src/test/resources/META-INF/services/com.attackonarchitect.filter.chain.Filter
@@ -1,0 +1,6 @@
+project.filter.FirstFilter
+project.filter.SecondFilter
+project.filter.ThirdFilter
+project.filter.FourthFilter
+project.filter.FifthFilter
+project.filter.SixthFilter

--- a/mimic-tomcat/src/test/resources/META-INF/services/com.attackonarchitect.listener.request.ServletContextListener
+++ b/mimic-tomcat/src/test/resources/META-INF/services/com.attackonarchitect.listener.request.ServletContextListener
@@ -1,0 +1,1 @@
+project.listener.SimpleContextListener

--- a/mimic-tomcat/src/test/resources/META-INF/services/com.attackonarchitect.servlet.Servlet
+++ b/mimic-tomcat/src/test/resources/META-INF/services/com.attackonarchitect.servlet.Servlet
@@ -1,0 +1,5 @@
+project.servlet.DefaultServlet
+project.servlet.FirstServlet
+project.servlet.subservlet.SecondServlet
+project.servlet.subservlet.ThirdServlet
+project.servlet.subservlet.FourhServlet

--- a/mimic-tomcat/src/test/resources/WEB-INF/web.xml
+++ b/mimic-tomcat/src/test/resources/WEB-INF/web.xml
@@ -34,4 +34,28 @@
         <servlet-name>test</servlet-name>
         <url-pattern>/hello/*</url-pattern>
     </servlet-mapping>
+
+    <!--配置过滤器-->
+    <filter>
+        <filter-name>firstFilter</filter-name>
+        <filter-class>project.filter.FirstFilter</filter-class>
+    </filter>
+    <!--映射过滤器-->
+    <filter-mapping>
+        <filter-name>firstFilter</filter-name>
+        <!--“/*”表示拦截所有的请求 -->
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <!--配置过滤器-->
+    <filter>
+        <filter-name>secondFilter</filter-name>
+        <filter-class>project.filter.SecondFilter</filter-class>
+    </filter>
+    <!--映射过滤器-->
+    <filter-mapping>
+        <filter-name>secondFilter</filter-name>
+        <!--“/*”表示拦截所有的请求 -->
+        <url-pattern>/hello/*</url-pattern>
+    </filter-mapping>
 </web-app>

--- a/mimic-tomcat/src/test/resources/WEB-INF/web.xml
+++ b/mimic-tomcat/src/test/resources/WEB-INF/web.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0"
+         metadata-complete="true">
+    <display-name>learn</display-name>
+    <description>learn</description>
+
+    <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
+        <welcome-file>index.xhtml</welcome-file>
+        <welcome-file>index.htm</welcome-file>
+        <welcome-file>index.jsp</welcome-file>
+    </welcome-file-list>
+
+    <listener>
+        <listener-class>project.listener.SimpleContextListener</listener-class>
+    </listener>
+
+    <servlet>
+        <servlet-name>test</servlet-name>
+        <servlet-class>project.servlet.FirstServlet</servlet-class>
+        <!--
+        <init-param>
+            <param-name>testParamName</param-name>
+            <param-value>testParamValue</param-value>
+        </init-param>
+        -->
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>test</servlet-name>
+        <url-pattern>/hello/*</url-pattern>
+    </servlet-mapping>
+</web-app>


### PR DESCRIPTION
Fixed #4 
主要实现在: 
#### xml读取
[xml读取组件](mimic-tomcat/src/main/java/com/attackonarchitect/XmlComponentScanner.java)
格式为传统tomcat读取
示例文件在 [web.xml](mimic-tomcat/src/test/resources/WEB-INF/web.xml)

#### spi读取
[spi读取组件](mimic-tomcat/src/main/java/com/attackonarchitect/SpiComponentScanner.java)
格式为java默认的ServiceLoader读取
然后根据指定的实现类上的配置信息完成初始化
